### PR TITLE
bugfix: alaska/alabama alphabetization

### DIFF
--- a/data.json
+++ b/data.json
@@ -17606,12 +17606,12 @@
     "countryShortCode":"US",
     "regions":[
       {
-        "name":"Alaska",
-        "shortCode":"AK"
-      },
-      {
         "name":"Alabama",
         "shortCode":"AL"
+      },
+      {
+        "name":"Alaska",
+        "shortCode":"AK"
       },
       {
         "name":"American Samoa",


### PR DESCRIPTION
Alaska came before Alabama; Alabama should come first.