### PR TITLE
Add missing Nouvelle-Aquitaine in France

### DIFF
--- a/data.json
+++ b/data.json
@@ -4776,6 +4776,10 @@
         "shortCode": "NOR"
       },
       {
+        "name":"Nouvelle-Aquitaine",
+        "shortCode": "NAQ"
+      },
+      {
         "name":"Occitanie",
         "shortCode": "OCC"
       },


### PR DESCRIPTION
It misses one of the biggest region in France, [Nouvelle-Aquitaine](https://en.wikipedia.org/wiki/Nouvelle-Aquitaine).