### PR TITLE
Add an "exports" field with conditional entry points to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
   "main": "dist/data-umd.js",
   "module": "dist/data.js",
   "typings": "dist/data.d.ts",
+  "exports": {
+    "types": "./dist/data.d.ts",
+    "import": "./dist/data.js",
+    "require": "./dist/data-umd.js"
+  },
   "scripts": {
     "test": "grunt validate",
     "build": "grunt build"


### PR DESCRIPTION
This change is intended to address issues with resolving an ESM import from Vitest, as discussed in https://github.com/country-regions/country-region-data/issues/148

- For an explanation of entry points and the "exports" field, see https://nodejs.org/api/packages.html#package-entry-points
- The "import" and "require" conditions are defined in https://nodejs.org/api/packages.html#conditional-exports
- The "types" condition is defined in https://nodejs.org/api/packages.html#community-conditions-definitions