### PR TITLE
add Luuka region to Uganda

### DIFF
--- a/data.json
+++ b/data.json
@@ -16608,6 +16608,10 @@
         "shortCode": "116"
       },
       {
+        "name": "Luuka",
+        "shortCode": "229"
+      },
+      {
         "name": "Manafwa",
         "shortCode": "221"
       },


### PR DESCRIPTION
This PR adds Luuka to the list of Uganda regions.
Luuka is an official district of Uganda. It was missing from the current dataset.

Follow-up to my first PR, moving the change as suggested.